### PR TITLE
Export of field propagation (kick) interpolation: non klinear kicker as example

### DIFF
--- a/python/examples/nlk.py
+++ b/python/examples/nlk.py
@@ -1,0 +1,82 @@
+import thor_scsi.lib as tslib
+from thor_scsi.elements.air_coil import NonlinearKickerField, AirCoilMagneticField
+from thor_scsi.pyflame import Config
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def plot_field():
+    ref_pos = 20e-3 + 10e-3j
+    t_current = 7e2
+
+    nlkf = NonlinearKickerField(position=ref_pos, current=t_current)
+    left = AirCoilMagneticField(
+        positions=np.array([ref_pos, ref_pos.conjugate()]),
+        currents=np.array([-t_current, t_current]),
+    )
+    right = AirCoilMagneticField(
+        positions=np.array([-ref_pos.conjugate(), -ref_pos]),
+        currents=np.array([t_current, -t_current]),
+    )
+    print(nlkf, left, right)
+    x = np.linspace(-30e-3, 30e-3, num=300)
+    pos = np.zeros([len(x), 2], dtype=np.float)
+    pos[:, 0] = x
+
+    fig, axes = plt.subplots(1, 2, sharex=True)
+    ax_x, ax_y = axes
+    B = np.zeros([len(x), 2], dtype=np.float)
+    [nlkf.field_py(tp, tB) for tp, tB in zip(pos, B)]
+    ax_x.plot(x, B[:, 0], "-", label="nlk")
+    ax_y.plot(x, B[:, 1], "-", label="nlk")
+    ax_x.set_xlabel("x")
+    ax_y.set_xlabel("y")
+
+    B = np.zeros([len(x), 2], dtype=np.float)
+    [left.field_py(tp, tB) for tp, tB in zip(pos, B)]
+    ax_x.plot(x, B[:, 0], "--", label="left")
+    ax_y.plot(x, B[:, 1], "--", label="left")
+
+    B = np.zeros([len(x), 2], dtype=np.float)
+    [right.field_py(tp, tB) for tp, tB in zip(pos, B)]
+    ax_x.plot(x, B[:, 0], "-.", label="right")
+    ax_y.plot(x, B[:, 1], "-.", label="right")
+
+
+def main():
+    ref_pos = 20e-3 + 10e-3j
+    t_current = 1e3
+
+    nlkf = NonlinearKickerField(position=ref_pos, current=t_current)
+    print(nlkf)
+
+    C = Config()
+    C.setAny("L", 0e0)
+    C.setAny("name", "nlk")
+    C.setAny("N", 1)
+
+    nlk = tslib.FieldKick(C)
+    nlk.setFieldInterpolator(nlkf)
+
+    print(repr(nlk))
+    ps = tslib.ss_vect_double()
+    ps.set_zero()
+    config = tslib.ConfigType()
+    print("propagate center")
+    nlk.propagate(config, ps)
+    print("pos", ps)
+
+    ps = tslib.ss_vect_double()
+    ps.set_zero()
+    x_off = 10.0e-3
+    ps[0] = x_off
+    config = tslib.ConfigType()
+    print("propagate offset x={x_off}")
+    nlk.propagate(config, ps)
+    print("pos", ps)
+
+
+if __name__ == "__main__":
+    # plot_field()
+    # plt.show()
+    main()

--- a/python/examples/single_wire.py
+++ b/python/examples/single_wire.py
@@ -1,0 +1,86 @@
+import thor_scsi.lib as tslib
+from thor_scsi.elements.air_coil import AirCoilMagneticField
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+class SingleWire(AirCoilMagneticField):
+    """A single wire in space
+
+    Used to check the properties of the potential
+    """
+
+    def __init__(self, *, position, current):
+        pos = position
+        positions = np.array([pos])
+        currents = np.array([current])
+        AirCoilMagneticField.__init__(self, positions=positions, currents=currents)
+
+
+# position of the wire
+w_pos = (20 + 10j) * 1e-3
+sgw = SingleWire(position=w_pos, current=700)
+x = np.linspace(0, w_pos.real * 2, num=20 * 2 * 10 + 1)
+y = np.linspace(0, w_pos.imag * 2, num=10 * 2 * 10 + 1)
+
+X, Y = np.meshgrid(x, y)
+
+pos = np.zeros(X.shape + (2,))
+pos[..., 0] = X
+pos[..., 1] = Y
+B = np.zeros(X.shape + (2,))
+rB = B.reshape(-1, 2)
+rpos = pos.reshape(-1, 2)
+
+[sgw.field_py(p, rb) for p, rb in zip(rpos, rB)]
+
+print(rB[..., 0].max(), rB[..., 0].max())
+print(rB[..., 1].max(), rB[..., 1].max())
+
+B = rB.reshape(X.shape + (2,))
+
+r = 3e-3
+w_idx = ((pos[..., 0] - w_pos.real) ** 2 + (pos[..., 1] - w_pos.imag) ** 2) < r ** 2
+
+B[w_idx, 0] = np.nan
+B[w_idx, 1] = np.nan
+fig, axes = plt.subplots(1, 3)
+ax_x, ax_y, ax_a = axes
+extent = np.array([x.min(), x.max(), y.min(), y.max()]) * 1e3
+print(B[..., 0].max(), B[..., 0].max())
+print(B[..., 1].max(), B[..., 1].max())
+ax_x.imshow(B[..., 0], extent=extent, origin="lower")
+ax_y.imshow(B[..., 1], extent=extent, origin="lower")
+
+Ba = np.absolute(B[..., 0] + B[..., 1] * 1j)
+ax_a.imshow(np.log(Ba), extent=extent, origin="lower")
+
+
+phi = np.linspace(0, 2 * np.pi, num=1000)
+R = r
+probe = r * np.exp(phi * 1j) + w_pos
+probe_pos = np.zeros((len(probe), 2))
+probe_pos[:, 0] = probe.real
+probe_pos[:, 1] = probe.imag
+Bp = np.zeros((len(probe), 2))
+
+pphi = phi * 180 / np.pi
+
+
+fig, axes = plt.subplots(1, 3)
+ax_x, ax_y, ax_a = axes
+
+ax_x.plot(pphi, probe_pos[:, 0])
+ax_y.plot(pphi, probe_pos[:, 1])
+ax_a.plot(pphi, np.absolute(probe - w_pos))
+[sgw.field_py(p, rb) for p, rb in zip(probe_pos, Bp)]
+
+fig, axes = plt.subplots(1, 3)
+ax_x, ax_y, ax_a = axes
+
+Ba = Bp[:, 0] * np.sin(phi) + Bp[:, 1] * np.cos(phi)
+ax_x.plot(pphi, Bp[:, 0])
+ax_y.plot(pphi, Bp[:, 1])
+ax_a.plot(pphi, Ba)
+
+plt.show()

--- a/python/tests/multipoles_test.py
+++ b/python/tests/multipoles_test.py
@@ -22,7 +22,7 @@ def test10_multiply_multipoles():
     assert mul.getMultipole(2).real == pytest.approx(8)
 
 
-def test11_multiply_multipoles_scalar():
+def test11_multiply_multipoles_scalar_int():
     mul = tslib.TwoDimensionalMultipoles()
     mul.setMultipole(1, 2)
     mul.setMultipole(2, 4)
@@ -32,6 +32,45 @@ def test11_multiply_multipoles_scalar():
     print(mul)
 
     n_mul = mul * 2
+    # Former multipoles still the same
+    assert mul.getMultipole(1).real == pytest.approx(2)
+    assert mul.getMultipole(2).real == pytest.approx(4)
+
+    assert n_mul.getMultipole(1).real == pytest.approx(4)
+    assert n_mul.getMultipole(2).real == pytest.approx(8)
+
+
+def test11_multiply_multipoles_scalar_float():
+    mul = tslib.TwoDimensionalMultipoles()
+    mul.setMultipole(1, 2)
+    mul.setMultipole(2, 4)
+
+    assert mul.getMultipole(1).real == pytest.approx(2)
+    assert mul.getMultipole(2).real == pytest.approx(4)
+    print(mul)
+
+    n_mul = mul * float(2.0)
+    # Former multipoles still the same
+    assert mul.getMultipole(1).real == pytest.approx(2)
+    assert mul.getMultipole(2).real == pytest.approx(4)
+
+    assert n_mul.getMultipole(1).real == pytest.approx(4)
+    assert n_mul.getMultipole(2).real == pytest.approx(8)
+
+def test12_multiply_multipoles_scalar_float():
+    """float on the other side ...
+
+    Commutative law needs to be explicitly implemented
+    """
+    mul = tslib.TwoDimensionalMultipoles()
+    mul.setMultipole(1, 2)
+    mul.setMultipole(2, 4)
+
+    assert mul.getMultipole(1).real == pytest.approx(2)
+    assert mul.getMultipole(2).real == pytest.approx(4)
+    print(mul)
+
+    n_mul = float(2.0) * mul
     # Former multipoles still the same
     assert mul.getMultipole(1).real == pytest.approx(2)
     assert mul.getMultipole(2).real == pytest.approx(4)

--- a/python/thor_scsi/elements/air_coil.py
+++ b/python/thor_scsi/elements/air_coil.py
@@ -1,0 +1,121 @@
+"""
+"""
+import thor_scsi.lib as tslib
+import numpy as np
+
+mu0 = 4 * np.pi * 1e-7
+
+
+class AirCoilMagneticField(tslib.Field2DInterpolation):
+    """Magnetic field created by an 2D air coil magnet
+
+
+    Warning:
+        If a function defined as a virtual function does not
+        exist it will crash the interpreter ...
+
+
+    Precomputes the factor
+
+    .. math::
+       \\frac{I \\mu_0}{2 \\pi}
+    """
+    def __init__(self, *, positions, currents):
+        """
+
+        Args:
+            positions: transversal position of the individual wires
+            currents:  current flowing through the wires
+        """
+        tslib.Field2DInterpolation.__init__(self)
+
+        self.positions = positions
+        self.currents = currents
+
+        #  \mu_0
+        # ---------
+        #  2*pi
+
+        factor = mu0 / (2 * np.pi)
+
+        self.precomp = factor * self.currents  # * lp_inv
+
+    def field_py(self, pos, field):
+        """Calculate field created by the wires
+
+        Internally calculating in the complex plane
+        """
+        x = float(pos[0])
+        y = float(pos[1])
+        z = x + y * 1j
+
+        dz = z - self.positions
+        r = np.absolute(dz)
+        phi = np.angle(dz)
+        Bphi = self.precomp * 1 / r
+
+        # Bphi 90 degree to radius vector
+        B = Bphi * np.exp((phi + np.pi / 2) * 1j)
+        B = B.sum()
+        field[0] = B.imag
+        field[1] = B.real
+
+    def gradient_py(self, pos, gradient):
+        raise NotImplementedError("gradient not (yet) implemented")
+
+    def field(self, x, y, Bx, By):
+        raise NotImplementedError("Don't know how to handle this function here ")
+
+    def gradient(self, x, y, Bx, By):
+        raise NotImplementedError("Gradient not implemented")
+
+    def __repr__(self):
+        cls_name = self.__class__.__name__
+        pos = self.positions
+        cur = self.currents
+        return f"{cls_name}(positions={pos}, currents={cur})"
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class NonlinearKickerField(AirCoilMagneticField):
+    """Nonlinear kicker field
+
+    Field created by a classical telephone transmission cable
+
+    Here the interest is within the conductors while the classical's
+    application focus was on minimising the field on the outside
+    (thus reducing cross talk to other conversations)
+
+    See
+
+    "DEVELOPMENT OF A NON-LINEAR KICKER SYSTEM TO FACILITATE
+    A NEW INJECTION SCHEME FOR THE BESSY II STORAGE RING"
+
+    T. Atkinson, M. Dirsat, O. Dressler, P. Kuske, H. Rast,
+    Proceedings of IPAC2011, San Sebastián, Spain, THPO024
+    2011
+    """
+
+    def __init__(self, *, position, current):
+        pos = position
+        #
+        positions = np.array(
+            [
+                # right upper
+                pos,
+                # right lower
+                pos.conjugate(),
+                # left upper
+                -pos.conjugate(),
+                # left lower
+                -pos,
+            ]
+        )
+        currents = np.array([current] * len(positions))
+        currents *= [1, -1, -1, 1]
+        AirCoilMagneticField.__init__(self, positions=positions, currents=currents)
+
+
+__all__ = ["AirCoilMagneticField", "NonlinearKickerField"]

--- a/src/thor_scsi/core/multipoles.cc
+++ b/src/thor_scsi/core/multipoles.cc
@@ -2,6 +2,7 @@
 #include <thor_scsi/core/math_comb.h>
 #include <tps/utils.h>
 #include <algorithm>
+#include <iostream>
 
 namespace tsc = thor_scsi::core;
 
@@ -48,24 +49,78 @@ tsc::TwoDimensionalMultipoles::TwoDimensionalMultipoles(std::vector<cdbl_intern>
 	if(coeffs.size()<=1){
 		throw std::logic_error("max multipole must be at least 1");
 	}
-	this->coeffs = coeffs;
+	std::vector<cdbl_intern> n_vec(coeffs.begin(), coeffs.end());
+	this->coeffs = n_vec;
 	this->m_max_multipole = this->coeffs.size();
+}
+
+
+tsc::TwoDimensionalMultipoles& tsc::TwoDimensionalMultipoles::right_multiply(const std::vector<double> &scale, const bool begnin)
+{
+	auto& c = this->coeffs;
+	size_t n_coeff = c.size(), n_scale = scale.size();
+
+	if(begnin){
+		if(n_coeff > n_scale){
+			// Check for exception matching python length error
+			std::stringstream strm;
+			strm << "Received " << n_scale << " elements for scaling."
+			     << " being begnin I would ignore excess elements. but I got only "
+			     << n_coeff     << " .";
+			throw std::runtime_error(strm.str());
+		}
+	} else {
+		if(n_coeff != n_scale){
+			// Check for exception matching python length error
+			std::stringstream strm;
+			strm << "Received " << n_scale << " elements for scaling."
+			     << " this does not match the number of coefficients " << n_coeff
+			     << " .";
+			throw std::runtime_error(strm.str());
+		}
+	}
+	std::transform(c.begin(), c.end(), scale.begin(), c.begin(), std::multiplies<>());
+	return *this;
+
+}
+
+tsc::TwoDimensionalMultipoles& tsc::TwoDimensionalMultipoles::right_add(const TwoDimensionalMultipoles &other, const bool begnin)
+{
+
+	auto& c = this->coeffs;
+	size_t n_coeff = c.size(), n_add = other.size();
+
+	if(begnin){
+		if(n_coeff >  n_add){
+			// Check for exception matching python length error
+			std::stringstream strm;
+			strm << "Received " << n_add << " elements for adding."
+			     << " being begnin I would ignore excess elements. But I got only " << n_coeff
+			     << " .";
+			throw std::runtime_error(strm.str());
+		}
+	} else {
+		if(n_coeff != n_add){
+			// Check for exception matching python length error
+			std::stringstream strm;
+			strm << "Received " << n_add << " elements for adding."
+			     << " this does not match the number of coefficients " << n_coeff
+			     << ".";
+			throw std::runtime_error(strm.str());
+		}
+	}
+	auto& oc = other.getCoeffs();
+
+	std::transform(c.begin(), c.end(), oc.begin(), c.begin(), std::plus<>());
+
+	return *this;
+
 }
 
 tsc::TwoDimensionalMultipoles& tsc::TwoDimensionalMultipoles::operator *= (const std::vector<double> &scale)
 {
-	auto& c = this->coeffs;
-	size_t n_coeff = c.size(), n_scale = scale.size();
-	if(n_coeff != n_scale){
-		// Check for exception matching python length error
-		std::stringstream strm;
-		strm << "Received " << n_scale << " elements for scaling."
-		     << " this does not match the number of coefficients " << n_coeff
-		     << " .";
-		std::runtime_error(strm.str());
-	}
-	std::transform(c.begin(), c.end(), scale.begin(), c.begin(), std::multiplies<>());
-	return *this;
+	// should be false ... leave it that way to get further with prototyping
+	return this->right_multiply(scale, true);
 }
 
 tsc::TwoDimensionalMultipoles  tsc::TwoDimensionalMultipoles::operator * (const std::vector<double> &scale) const
@@ -76,28 +131,46 @@ tsc::TwoDimensionalMultipoles  tsc::TwoDimensionalMultipoles::operator * (const 
 }
 
 tsc::TwoDimensionalMultipoles& tsc::TwoDimensionalMultipoles::operator += (const tsc::TwoDimensionalMultipoles &other)
+
 {
+	// should be false ... leave it that way to get further with prototyping
+	return this->right_add(other, true);
 
-	if(this->getCoeffs().size() != other.getCoeffs().size()){
-		throw std::runtime_error("Length of coeffcients does not match");
-	}
-	auto& c = this->getCoeffs();
-	auto& oc = other.getCoeffs();
-
-	std::transform(oc.begin(), oc.end(), c.begin(), c.begin(), std::plus<>());
-
-	return *this;
 }
+
 
 tsc::TwoDimensionalMultipoles tsc::TwoDimensionalMultipoles::operator+ (const tsc::TwoDimensionalMultipoles &other) const
 {
 
-	unsigned int n = std::max(this->getCoeffs().size(), other.getCoeffs().size());
-	TwoDimensionalMultipoles nh(n);
-	nh += *this;
+	// unsigned int n = std::max(this->getCoeffs().size(), other.getCoeffs().size());
+	std::cerr << "Adding multipoles. this size " << this->getCoeffs().size()
+		  << " others size" << other.getCoeffs().size()
+		  << std::endl;
+	TwoDimensionalMultipoles nh = this->clone();
 	nh += other;
 	return nh;
 
+}
+
+
+tsc::TwoDimensionalMultipoles& tsc::TwoDimensionalMultipoles::operator += (const double other)
+{
+
+	auto& c = this->getCoeffs();
+	for (auto& val : c){
+		val += other;
+	}
+	return *this;
+}
+
+tsc::TwoDimensionalMultipoles tsc::TwoDimensionalMultipoles::operator+ (const double other) const
+{
+
+	TwoDimensionalMultipoles nh = this->clone();
+	std::cerr << "Adding const "<< other << "to these multipoles. this size " << this->getCoeffs().size()
+		  << std::endl;
+	nh += other;
+	return nh;
 }
 
 void tsc::TwoDimensionalMultipoles::show(std::ostream& strm, int level) const
@@ -132,6 +205,48 @@ void tsc::TwoDimensionalMultipoles::applyTranslation(const tsc::cdbl dzs)
 	}
 }
 
+
+#if 0
+
+tsc::BegninTwoDimensionalMultipolesDelegator tsc::BegninTwoDimensionalMultipolesDelegator::clone(void) const
+{
+	tsc::TwoDimensionalMultipoles nh = this->delegate->clone();
+        std::shared_ptr<tsc::TwoDimensionalMultipoles> ptr(nh);
+	tsc::BegninTwoDimensionalMultipolesDelegator nd(ptr);
+	return nd;
+}
+
+tsc::BegninTwoDimensionalMultipolesDelegator& tsc::BegninTwoDimensionalMultipolesDelegator::operator += (const tsc::TwoDimensionalMultipoles &other)
+{
+	this->delegate->right_add(other, true);
+	return *this;
+
+}
+
+tsc::BegninTwoDimensionalMultipolesDelegator& tsc::BegninTwoDimensionalMultipolesDelegator::operator *= (const std::vector<double> &scale)
+{
+	this->delegate->right_multiply(scale, true);
+	return *this;
+}
+
+
+
+tsc::BegninTwoDimensionalMultipolesDelegator tsc::BegninTwoDimensionalMultipolesDelegator::operator * (const std::vector<double> &scale) const
+{
+	auto nh = this->clone();
+	nh *= scale;
+	return nh;
+}
+
+
+tsc::BegninTwoDimensionalMultipolesDelegator tsc::BegninTwoDimensionalMultipolesDelegator::operator + (const tsc::TwoDimensionalMultipoles &other) const
+{
+	auto nh = this->clone();
+	nh += other;
+	return nh;
+}
+
+#endif
 
 /*
  * Local Variables:

--- a/src/thor_scsi/elements/field_kick_api.h
+++ b/src/thor_scsi/elements/field_kick_api.h
@@ -32,6 +32,9 @@ namespace thor_scsi::elements {
 			return this->integration_steps;
 		}
 
+		inline void setFieldInterpolator(std::shared_ptr<thor_scsi::core::Field2DInterpolation> a_intp){
+			this->intp = a_intp;
+		}
 		inline auto getFieldInterpolator(void) const {
 			/*
 			  std::cerr << "Getting field interpolator " <<  std::endl;

--- a/src/thor_scsi/elements/mpole.h
+++ b/src/thor_scsi/elements/mpole.h
@@ -36,6 +36,13 @@ namespace thor_scsi::elements {
 			return std::const_pointer_cast<thor_scsi::core::TwoDimensionalMultipoles>(p);
 		}
 
+		inline void setFieldInterpolator(std::shared_ptr<thor_scsi::core::TwoDimensionalMultipoles> intp) {
+			auto p = std::dynamic_pointer_cast<thor_scsi::core::Field2DInterpolation>(intp);
+			if(!p){
+				throw std::runtime_error("Could not cast multipole to Field2DInterpolation");
+			}
+			this->intp = p;
+		}
 
 		//thor_scsi::core::TwoDimensionalMultipoles* intp;
 	};


### PR DESCRIPTION
Partly covers exports of multipoles: preparation for engineering

src/fieldkick:
    * access to interpolator object

src/multipoles:
    * preparation for engineering / robust design studies
    * interface for "begnin" multipoles (e.g. ignoring scaling vector wit superflous constants)

src/mpole:
    * access to multipoles

python/elements:
    * field interpolation: methods to overrride
    * field propagation / field kick: allow setting / getting field interpolation
    * multipoles: added tests
    * air_coil: now caluculating field directly, addded non linear kicker here

python examples:
   * field for non linear kicker
   * field for single wire

Field kick requires to be renamed to propagate