### PR TITLE
Radiate: clang compatible, energy defaults to NaN

### DIFF
--- a/python/src/elements.cc
+++ b/python/src/elements.cc
@@ -137,52 +137,65 @@ class PyField2DInterpolation: public tsc::Field2DInterpolation{
 public:
 	using tsc::Field2DInterpolation::Field2DInterpolation;
 #if 0
-	// clang g++-11 not accepting this code yet
-	void field_py(const py::array<double, 2> pos, std::array<double, 2> field) const {
+	void field_py(const std::array<double, 2> pos, std::array<double, 2> field) const {
 		PYBIND11_OVERRIDE_PURE(void, PyField2DInterpolationIntermediate, field_py, pos, field);
 	}
-	virtual void field_py(const py::array_t<double> &t_pos, py::array_t<double> &t_field) const {
+#endif
+	// clang now accepting this code
+	// needs to be tested if it still works as expected (data can be returned)
+	// originally made for non linear kicker
+	// this way it does not work ....
+	virtual void field_py    (const py::array_t<double>  &t_pos, py::array_t<double> &t_field) const {
 		PYBIND11_OVERRIDE(void, PyField2DInterpolation, field_py, t_pos, t_field);
 	}
-	virtual void field_py(const py::array_t<tps> &t_pos, py::array_t<tps> &t_field) const {
-		PYBIND11_OVERRIDE(void, PyField2DInterpolation, field_py, t_pos, t_field);
+	virtual void field_py    (const std::array<tps*   , 2>  &t_pos, std::array<tps*   , 2> &t_field) const {
+		PYBIND11_OVERRIDE(void, PyField2DInterpolation, field_py   , t_pos, t_field);
 	}
-	virtual void gradient_py(const std::array<double, 2> &t_pos, std::array<double, 2> &t_field) const {
+#if 0
+	virtual void gradient_py (const std::array<double&, 2> &t_pos, std::array<double& , 2> &t_field) const {
 		PYBIND11_OVERRIDE(void, PyField2DInterpolation, gradient_py, t_pos, t_field);
 	}
-	virtual void gradient_py(const std::array<tps, 2> &t_pos, std::array<tps, 2> &t_field) const {
+	virtual void gradient_py (const std::array<tps&   , 2>  &t_pos, std::array<tps&   , 2> &t_field) const {
 		PYBIND11_OVERRIDE(void, PyField2DInterpolation, gradient_py, t_pos, t_field);
 	}
-	virtual void gradient_py(const std::array<tps, 2> &t_pos, std::array<double, 2> &t_field) const {
+	virtual void gradient_py (const std::array<tps&   , 2>  &t_pos, std::array<double&, 2> &t_field) const {
 		PYBIND11_OVERRIDE(void, PyField2DInterpolation, gradient_py, t_pos, t_field);
 	}
 #endif
 private:
-	template<typename T>
-	inline void _field(const T x, const T y, T *Bx, T *By) const {
-		auto pos = py::array_t<T>({2}), t_field = py::array_t<T>({2});
-		T *pos_p = static_cast<T *>(pos.request().ptr),
-			*field_p = static_cast<T *>(t_field.request().ptr);
-		pos_p[0] = x;
-		pos_p[1] = y;
-		// clang g++-11 not accepting this code yet
-		// this->field_py(pos, t_field);
-		*Bx = field_p[0];
-		*By = field_p[1];
 
-		std::cerr << "By " << *By <<  ",  Bx" <<  *Bx << std::endl;
-	}
 	template<typename T>
 	inline void _gradient(const T x, const T y, T *Bx, T *By) const {
+		throw std::runtime_error("Not implemented");
 	}
 
 public:
 	void field(const double x, const double y, double *Bx, double *By) const override {
-		this->_field(x, y, Bx, By);
+		auto pos = py::array_t<double>({2});
+		auto t_field = py::array_t<double>({2});
+		double *pos_p = static_cast<double *>(pos.request().ptr),
+			*field_p = static_cast<double *>(t_field.request().ptr);
+		pos_p[0] = x;
+		pos_p[1] = y;
+		// this->field_py(pos, t_field);
+		*Bx = field_p[0];
+		*By = field_p[1];
+
+		/*
+		std::cerr << "x " << x << ", y "
+			  << ", By " << *By <<  ",  Bx " <<  *Bx
+			  << std::endl;
+		*/
 	}
+
 	void field(const tps x, const tps y, tps *Bx, tps *By) const override {
 		//this->_field(x, y, Bx, By);
-		throw std::runtime_error("field with tps to python not implemented");
+		std::array<tps, 2> pos = {x, y};
+		std::array<tps*, 2> t_field = {Bx, By};
+		// this->field_py(pos, t_field);
+		//*Bx = t_field[0];
+		//*By = t_field[1];
+
 	}
 	void gradient(const double x, const double y, double *Gx, double *Gy) const  override{
 		PYBIND11_OVERRIDE_PURE(void, tsc::Field2DInterpolation, gradient, x, y, Gx, Gy);

--- a/src/thor_scsi/core/aperture.h
+++ b/src/thor_scsi/core/aperture.h
@@ -22,6 +22,7 @@ namespace thor_scsi::core {
 		 * Rationale: support optimisations that want to get the beam
 		 * close to a boundary. For centre, optimisation use the center
 		 */
+		virtual ~TwoDimensionalAperture(void) {};
 		virtual double isWithin(const double x, const double y) const = 0;
 		virtual void show(std::ostream&, int level) const;
 

--- a/src/thor_scsi/core/config.h
+++ b/src/thor_scsi/core/config.h
@@ -57,7 +57,7 @@ namespace thor_scsi {
 				Omega = 0e0,                        //< Synchrotron Frequency.
 				U0 = 0e0,                           //< Energy Loss per turn [keV].
 				Alphac = 0e0,                       //< Linear Momentum Compaction.
-				Energy = 1.7e9,                     //< Beam Energy in eV.
+				Energy = NAN,                       //< Beam Energy in eV.
 				dE = 0e0,                           //< Energy Loss.
 				CODeps = 1e-6,                       //< Closed Orbit precision.
 				Qb= 0e0,                           //< Bunch Charge.

--- a/src/thor_scsi/elements/radiation_delegate.h
+++ b/src/thor_scsi/elements/radiation_delegate.h
@@ -8,6 +8,7 @@
 namespace thor_scsi::elements {
 	class RadiationDelegate: public  RadiationDelegateInterface{
 	public:
+		~RadiationDelegate(void){};
 		inline RadiationDelegate(void){
 			this->reset();
 		}
@@ -23,7 +24,7 @@ namespace thor_scsi::elements {
 		 * Used for computing curly_dHx
 		 */
 		virtual void view(const ElemType& kick, const ss_vect<double> &ps, const enum ObservedState state, const int cnt) override;
-		virtual void view(const ElemType& kick, const ss_vect<tps> &ps, const enum ObservedState state, const int cnt) override;
+		virtual void view(const ElemType& kick, const ss_vect<tps>    &ps, const enum ObservedState state, const int cnt) override;
 
 		virtual void show(std::ostream& strm, int level) const override final;
 
@@ -50,6 +51,7 @@ namespace thor_scsi::elements {
 		RadiationDelegateKick(void){
 			this->reset();
 		}
+		~RadiationDelegateKick(void){};
 
 		/*
 		 * @brief: reset parameters for radiation
@@ -85,7 +87,7 @@ namespace thor_scsi::elements {
 		 * Used for computing synchrotron integrals
 		 */
 		virtual void view(const FieldKickAPI& kick, const ss_vect<double> &ps, const enum ObservedState state, const int cnt) override;
-		virtual void view(const FieldKickAPI& kick, const ss_vect<tps> &ps, const enum ObservedState state, const int cnt) override;
+		virtual void view(const FieldKickAPI& kick, const ss_vect<tps>    &ps, const enum ObservedState state, const int cnt) override;
 
 		virtual void show(std::ostream& strm, int level) const override final;
 		//virtual void view(const ElemType& kick, const ss_vect<double> &ps, const enum ObservedState state, const int cnt) override final;

--- a/src/thor_scsi/elements/radiation_delegate_api.h
+++ b/src/thor_scsi/elements/radiation_delegate_api.h
@@ -9,8 +9,9 @@ namespace thor_scsi::elements {
 	using thor_scsi::core::ObservedState;
 	class RadiationDelegateInterface {
 	public:
+		virtual ~RadiationDelegateInterface(void){}
 		virtual void view(const thor_scsi::core::ElemType& elem, const ss_vect<double> &ps, const enum ObservedState, const int cnt) = 0;
-		virtual void view(const thor_scsi::core::ElemType& elem, const ss_vect<tps> &ps, const enum ObservedState, const int cnt) = 0;
+		virtual void view(const thor_scsi::core::ElemType& elem, const ss_vect<tps>    &ps, const enum ObservedState, const int cnt) = 0;
 		virtual void show(std::ostream& strm, int level) const{
 			strm << "RadiationDelegateInterface";
 		}
@@ -20,8 +21,9 @@ namespace thor_scsi::elements {
 	};
 	class RadiationDelegateKickInterface {
 	public:
+		virtual ~RadiationDelegateKickInterface(void){}
 		virtual void view(const FieldKickAPI& kick, const ss_vect<double> &ps, const enum ObservedState, const int cnt) = 0;
-		virtual void view(const FieldKickAPI& kick, const ss_vect<tps> &ps, const enum ObservedState, const int cnt)  = 0;
+		virtual void view(const FieldKickAPI& kick, const ss_vect<tps>    &ps, const enum ObservedState, const int cnt)  = 0;
 		virtual void show(std::ostream& strm, int level) const{
 			strm << "RadiationDelegateKickInterface";
 		}

--- a/src/thor_scsi/elements/standard_observer.h
+++ b/src/thor_scsi/elements/standard_observer.h
@@ -46,7 +46,7 @@ namespace thor_scsi::elements{
 			this->m_has_ps = this->m_has_tps = false;
 		}
 
-		void show(std::ostream& strm, const int level) const;
+		void show(std::ostream& strm, const int level) const override final;
 
 		// python support
 		std::string repr(void) const;

--- a/src/thor_scsi/elements/test_cavity.cc
+++ b/src/thor_scsi/elements/test_cavity.cc
@@ -16,8 +16,18 @@ static double compute_delta(const double volt,  const double frequency, const do
 {
 	auto c0 = tse::speed_of_light;
 
+	/*
+	std::cout << "Frequency " << frequency/1e6 << " MHz"
+		  << " voltage  " << volt/1e6 << " MV "
+		  << " phase "  << phase
+		  << " energy "  << energy/1e9 << " GeV "
+		  << " ct / phase difference "  << ct;
+	*/
 	const double delta = - volt / (energy)
 			*sin(2e0*M_PI*frequency/c0*ct+phase);
+	/*
+	std::cout << " resuts in delta " << std::scientific << delta  << std::endl;
+	*/
 	return delta;
 }
 
@@ -25,18 +35,61 @@ static double compute_delta(const double volt,  const double frequency, const do
 BOOST_AUTO_TEST_CASE(test20_cavity)
 {
 
-	const double frequency=500e6, voltage=0.500e5;
+	const double frequency=500e6, voltage=500e3;
 	const double ct = 1e-3;
 	Config C;
 	C.set<std::string>("name", "test");
 	C.set<double>("Frequency", frequency);
 	C.set<double>("Voltage", voltage);
+	C.set<double>("harnum", 1);
 
 	tsc::ConfigType calc_config;
 	tse::CavityType cavity(C);
 
 	calc_config.Cavity_on = true;
+	calc_config.Energy = 1.7e9;
 
+	std::cout << "energy " << calc_config.Energy << std::endl;
+	const double delta = compute_delta(voltage, frequency, 0.0, calc_config.Energy, ct);
+
+	BOOST_CHECK_CLOSE(cavity.getVoltage(),   voltage,   1e-12);
+	BOOST_CHECK_CLOSE(cavity.getFrequency(), frequency, 1e-12);
+
+	const ss_vect<double> ps_orig = {0, 0, 0, 0, 0, ct};
+	BOOST_CHECK_CLOSE(ps_orig[ct_],   ct,   1e-12);
+
+
+	{
+		ss_vect<double> ps = ps_orig;
+		cavity.pass(calc_config, ps);
+
+		BOOST_CHECK_CLOSE(ps[ct_],    ct, 1e-14);
+		BOOST_CHECK_CLOSE(ps[delta_], delta, 1e-14);
+
+		BOOST_CHECK_SMALL(ps[x_],     1e-14);
+		BOOST_CHECK_SMALL(ps[y_],     1e-14);
+		BOOST_CHECK_SMALL(ps[px_],    1e-14);
+		BOOST_CHECK_SMALL(ps[py_],    1e-14);
+	}
+
+}
+
+BOOST_AUTO_TEST_CASE(test21_cavity_delta)
+{
+
+	const double frequency=499.036e6, voltage=1.5e6;
+	const double ct = 1e-3;
+	Config C;
+	C.set<std::string>("name", "test");
+	C.set<double>("Frequency", frequency);
+	C.set<double>("Voltage", voltage);
+	C.set<double>("harnum", 538);
+
+	tsc::ConfigType calc_config;
+	tse::CavityType cavity(C);
+
+	calc_config.Cavity_on = true;
+	calc_config.Energy = 2.5e9;
 	std::cout << "energy " << calc_config.Energy << std::endl;
 	const double delta = compute_delta(voltage, frequency, 0.0, calc_config.Energy, ct);
 


### PR DESCRIPTION
Cavity checks if energy is correctly set