### PR TITLE
 Synchrotron integrals reactivated, catchup with knobbable devices

### DIFF
--- a/python/src/accelerator.cc
+++ b/python/src/accelerator.cc
@@ -25,28 +25,8 @@ enum MachineLogLevel {
 	fine = THOR_SCSI_FINE
 };
 
-void py_thor_scsi_init_accelerator(py::module &m)
-{
 
-	// m.def("register_elements", &register_elements);
-	// needs to be done only once
-	ts::register_elements();
-
-	py::class_<tsc::Machine::LogRecord> log_record(m, "LogRecord");
-	py::class_<tsc::Machine::Logger, std::shared_ptr<tsc::Machine::Logger>> logger(m, "Logger");
-
-	const char prop_doc[] = "propagate phase space through elements";
-
-    py::enum_<MachineLogLevel>(m, "accelerator_log_level")
-	    .value("error",   MachineLogLevel::error)
-	    .value("warn",    MachineLogLevel::warn)
-	    .value("warning", MachineLogLevel::warning)
-	    .value("info",    MachineLogLevel::info)
-	    .value("debug",   MachineLogLevel::debug)
-	    .value("fine",    MachineLogLevel::fine);
-
-
-	const char acc_init_conf_doc[] = \
+static const char acc_init_conf_doc[] = \
 "initalise accelerator with a configuration file\n\
 \n\
 Args:\n\
@@ -57,7 +37,7 @@ Warning:\n\
   consider if the marker is not better added manually to the lattice\n\
   file\n";
 
-	const char acc_init_list_doc[] = \
+static const char acc_init_list_doc[] = \
 "initalise accelerator with a list of elements\n\
 \n\
 Args:\n\
@@ -68,48 +48,84 @@ Warning:\n\
   consider if the marker is not better added manually to the lattice\n\
   file";
 
-	py::class_<ts::Accelerator, std::shared_ptr<ts::Accelerator>>(m, "Accelerator")
-		.def("find",                 &ts::Accelerator::find)
+static const char prop_doc[] = "propagate phase space through elements";
+
+template<typename Types, typename Class>
+void add_methods_accelerator(py::class_<Class> t_acc)
+{
+	// using double_type = typename Types::double_type;
+
+	t_acc
+		.def("find",                 &Class::find)
 		// unique_ptr not working ... check for memory management ...
 		// should now be fixed with shared_ptrs
-		.def("elements_with_name",     &ts::Accelerator::elementsWithName)
+		.def("elements_with_name",     &Class::elementsWithName)
 		// unique_ptr not working ... check for memory management ...
-		.def("elements_with_name_type", &ts::Accelerator::elementsWithNameType)
-		.def("set_logger",            &ts::Accelerator::set_logger)
-		.def("set_log_level",          [](ts::Accelerator& acc, int level){
-						       acc.set_log_level(level);
-					       }, "set the log level, have a look to the accelerator log level enum")
+		.def("elements_with_name_type", &Class::elementsWithNameType)
+		.def("set_logger",            &Class::set_logger)
+		.def("set_log_level",          [](Class& t_acc, int level){
+			t_acc.set_log_level(level);
+		}, "set the log level, have a look to the accelerator log level enum")
 #if 0
-		.def("set_trace",             [](ts::Accelerator& acc, const bool flag){
-						      // Not used as
-						      py::scoped_ostream_redirect stream(
-							      std::cout,                               // std::ostream&
-							      py::module_::import("sys").attr("stdout") // Python output
-							      );
-						      acc.set_trace(std::cout);
-					      },  "activate trace output to std oute"
+		.def("set_trace",             [](Class& t_acc, const bool flag){
+			// Not used as
+			py::scoped_ostream_redirect stream(
+				std::cout,                               // std::ostream&
+				py::module_::import("sys").attr("stdout") // Python output
+				);
+			t_acc.set_trace(std::cout);
+		},  "activate trace output to std oute"
 			)
 #endif
-		//.def("__copy__",             &ts::Accelerator::clone, "make a copy of the accelerator")
-		.def("__len__",              &ts::Accelerator::size)
-		.def("__getitem__", py::overload_cast<size_t>(&ts::Accelerator::at))
-		.def("propagate", py::overload_cast<tsc::ConfigType&, ts::ss_vect_dbl&, size_t, int, size_t, bool>(&ts::Accelerator::propagate), prop_doc,
+		//.def("__copy__",             &Class::clone, "make a copy of the accelerator")
+		.def("__len__",              &Class::size)
+		.def("__getitem__", py::overload_cast<size_t>(&Class::at))
+		.def("propagate", py::overload_cast<tsc::ConfigType&, ts::ss_vect_dbl&, size_t, int, size_t, bool>(&Class::propagate), prop_doc,
 		     py::arg("calc_config"), py::arg("ps"), py::arg("start") = 0, py::arg("max_elements") = imax, py::arg("n_turns") = n_turns,
 		     py::arg("tracy_compatible") = false)
-             /*
-		.def("propagate", py::overload_cast<tsc::ConfigType&, ts::ss_vect_tps&, size_t, int, size_t, bool>(&ts::Accelerator::propagate), prop_doc,
+		/*
+		  .def("propagate", py::overload_cast<tsc::ConfigType&, ts::ss_vect_tps&, size_t, int, size_t, bool>(&Class::propagate), prop_doc,
 		     py::arg("calc_config"), py::arg("ps"), py::arg("start") = 0, py::arg("max_elements") = imax, py::arg("n_turns") = n_turns,
 		     py::arg("tracy_compatible") = false)
-              */
-		.def("propagate", py::overload_cast<tsc::ConfigType&, ts::ss_vect_tpsa&, size_t, int, size_t, bool>(&ts::Accelerator::propagate), prop_doc,
+		*/
+		.def("propagate", py::overload_cast<tsc::ConfigType&, ts::ss_vect_tpsa&, size_t, int, size_t, bool>(&Class::propagate), prop_doc,
 		     py::arg("calc_config"), py::arg("ps"), py::arg("start") = 0, py::arg("max_elements") = imax, py::arg("n_turns") = n_turns,
 		     py::arg("tracy_compatible") = false)
 		.def(py::init<const Config &, bool>(), acc_init_list_doc,
 		     py::arg("config object"), py::arg("add_marker_at_start") = false)
-		.def(py::init<const std::vector<std::shared_ptr<thor_scsi::core::ElemType>>&, bool>(), acc_init_list_doc,
-		     py::arg("elements"), py::arg("add_marker_at_start") = false)
-		;
 
+		.def(py::init<std::vector<std::shared_ptr<thor_scsi::core::CellVoid>>&, bool>(), acc_init_list_doc,
+		     py::arg("elements"), py::arg("add_marker_at_start") = false)
+
+		;
+}
+
+void py_thor_scsi_init_accelerator(py::module &m)
+{
+
+	// m.def("register_elements", &register_elements);
+	// needs to be done only once
+	ts::register_elements();
+
+	py::class_<tsc::Machine::LogRecord> log_record(m, "LogRecord");
+	py::class_<tsc::Machine::Logger, std::shared_ptr<tsc::Machine::Logger>> logger(m, "Logger");
+
+
+	py::enum_<MachineLogLevel>(m, "accelerator_log_level")
+		.value("error",   MachineLogLevel::error)
+		.value("warn",    MachineLogLevel::warn)
+		.value("warning", MachineLogLevel::warning)
+		.value("info",    MachineLogLevel::info)
+		.value("debug",   MachineLogLevel::debug)
+		.value("fine",    MachineLogLevel::fine);
+
+
+
+	py::class_<ts::Accelerator, std::shared_ptr<ts::Accelerator>> acc(m, "Accelerator");
+	add_methods_accelerator<tsc::StandardDoubleType, ts::Accelerator>(acc);
+
+	py::class_<ts::AcceleratorTpsa, std::shared_ptr<ts::AcceleratorTpsa>> accK(m, "AcceleratorTpsa");
+	  add_methods_accelerator<tsc::TpsaVariantType, ts::AcceleratorTpsa>(accK);
 
 
 }

--- a/python/src/elements.cc
+++ b/python/src/elements.cc
@@ -39,13 +39,13 @@ public:
 	}
 };
 
-template<class C>
-class PyElemType: public tsc::ElemTypeKnobbed<C>{
-	using base = tse::ElemTypeKnobbed <C>;
+// template<class C>
+class PyElemType: public tsc::ElemTypeKnobbed/*<C>*/{
+	using base = tse::ElemTypeKnobbed /*<C>*/;
 public:
-	// typedef tsc::ElemTypeKnobbed<C> _ElemType;
+	// typedef tsc::ElemTypeKnobbed/*<C>*/ _ElemType;
         PyElemType(const Config& config)
-		: tsc::ElemTypeKnobbed<C>(config)
+		: tsc::ElemTypeKnobbed/*<C>*/(config)
 		{}
 
 	void propagate(thor_scsi::core::ConfigType & conf, gtpsa::ss_vect<double>& ps) override {
@@ -124,10 +124,16 @@ class PyFieldKick: public tse::FieldKick {
 template<typename Types, typename Class>
 void add_methods_field_kick(py::class_<Class> t_mapper)
 {
+
+	using double_type = typename Types::double_type;
+
 	t_mapper
-		.def("set_dx",                          [](Class &kick, const double dx){kick.getTransform()->setDx(dx);})
-		.def("set_dy",                          [](Class &kick, const double dy){kick.getTransform()->setDy(dy);})
-		.def("set_roll",                        [](Class &kick, const double roll){kick.getTransform()->setRoll(roll);})
+		.def("set_dx",                          [](Class &kick, const double_type dx){kick.getTransform()->setDx(dx);})
+		.def("set_dy",                          [](Class &kick, const double_type dy){kick.getTransform()->setDy(dy);})
+		.def("set_roll",                        [](Class &kick, const double_type roll){kick.getTransform()->setRoll(roll);})
+		.def("get_dx",                          [](Class &kick){return kick.getTransform()->getDx();})
+		.def("get_dy",                          [](Class &kick){return kick.getTransform()->getDy();})
+		// .def("get_roll",                        [](Class &kick){kick.getTransform()->getRoll();})
 		.def("is_thick",                        &Class::isThick)
 		.def("as_thick",                        &Class::asThick)
 		.def("get_number_of_integration_steps", &Class::getNumberOfIntegrationSteps)
@@ -187,28 +193,11 @@ struct TemplatedClasses
 		, m_module(m)
   		{}
 
-	auto buildClasses(py::class_<tsc::CellVoid, std::shared_ptr<tsc::CellVoid>>& cell_void) {
-
-		std::string elem_type_name = "ElemType" + this->m_suffix;
-		py::class_<tsc::ElemTypeKnobbed<C>, PyElemType<C>,  std::shared_ptr<tsc::ElemTypeKnobbed<C>>> elem_type(this->m_module, elem_type_name.c_str(), cell_void);
-		elem_type.def(py::init<const Config &>());
-
-		elem_type
-			.def("__str__",        &tsc::ElemTypeKnobbed<C>::pstr)
-			.def("__repr__",       &tsc::ElemTypeKnobbed<C>::repr)
-			.def("get_length",     &tsc::ElemTypeKnobbed<C>::getLength)
-			.def("set_length",     &tsc::ElemTypeKnobbed<C>::setLength)
-			.def("get_observer",   &tsc::ElemTypeKnobbed<C>::observer)
-			.def("set_observer",   &tsc::ElemTypeKnobbed<C>::set_observer)
-			.def("get_aperture",   &tsc::ElemTypeKnobbed<C>::getAperture)
-			.def("set_aperture",   &tsc::ElemTypeKnobbed<C>::setAperture)
-			.def("propagate", py::overload_cast<tsc::ConfigType&, gtpsa::ss_vect<double>&>(&tse::ElemTypeKnobbed<C>::propagate), pass_d_doc)
-			.def("propagate", py::overload_cast<tsc::ConfigType&, gtpsa::ss_vect<gtpsa::tpsa>&>(&tse::ElemTypeKnobbed<C>::propagate), pass_d_doc)
-			//.def("propagate", py::overload_cast<tsc::ConfigType&, gtpsa::ss_vect<tps>&>(&tse::ElemType::propagate),    pass_tpsa_doc)
-                ;
+	//auto buildClasses(py::class_<tsc::CellVoid, std::shared_ptr<tsc::CellVoid>>& cell_void)
+	auto buildClasses(py::class_<tsc::ElemType, PyElemType, std::shared_ptr<tsc::ElemType>>& elem_type){
 
 		typedef tse::DriftTypeWithKnob<C> DriftTypeK;
-		std::string drift_type_name = "DriftType" + this->m_suffix;
+		std::string drift_type_name = "Drift" + this->m_suffix;
 		py::class_<DriftTypeK, std::shared_ptr<DriftTypeK>> drift(this->m_module, drift_type_name.c_str(), elem_type);
 		drift
 			.def(py::init<const Config &>());
@@ -284,15 +273,36 @@ void py_thor_scsi_init_elements(py::module &m)
 	cell_void
 		.def_readonly("name",  &tsc::CellVoid::name)
 		.def_readonly("index", &tsc::CellVoid::index)
+		.def("config", &tsc::CellVoid::conf)
 		;
+
+	std::string elem_type_name = "ElemType";
+	py::class_<tsc::ElemTypeKnobbed/*<C>*/, PyElemType/*<C>*/,  std::shared_ptr<tsc::ElemTypeKnobbed/*<C>*/>> elem_type(m, elem_type_name.c_str(), cell_void);
+	elem_type.def(py::init<const Config &>());
+
+	elem_type
+		.def("__str__",        &tsc::ElemTypeKnobbed/*<C>*/::pstr)
+		.def("__repr__",       &tsc::ElemTypeKnobbed/*<C>*/::repr)
+		.def("get_length",     &tsc::ElemTypeKnobbed/*<C>*/::getLength)
+		.def("set_length",     &tsc::ElemTypeKnobbed/*<C>*/::setLength)
+		.def("get_observer",   &tsc::ElemTypeKnobbed/*<C>*/::observer)
+		.def("set_observer",   &tsc::ElemTypeKnobbed/*<C>*/::set_observer)
+		.def("get_aperture",   &tsc::ElemTypeKnobbed/*<C>*/::getAperture)
+		.def("set_aperture",   &tsc::ElemTypeKnobbed/*<C>*/::setAperture)
+		.def("propagate", py::overload_cast<tsc::ConfigType&, gtpsa::ss_vect<double>&>(&tse::ElemTypeKnobbed/*<C>*/::propagate), pass_d_doc)
+		.def("propagate", py::overload_cast<tsc::ConfigType&, gtpsa::ss_vect<gtpsa::tpsa>&>(&tse::ElemTypeKnobbed/*<C>*/::propagate), pass_d_doc)
+			//.def("propagate", py::overload_cast<tsc::ConfigType&, gtpsa::ss_vect<tps>&>(&tse::ElemType::propagate),    pass_tpsa_doc)
+                ;
+
 
 	TemplatedClasses<tsc::StandardDoubleType> templated_classes_std(m, "");
 	// required as marker and bpm are not knobbed yet
-	auto elem_type = templated_classes_std.buildClasses(cell_void);
+	// auto elem_type =
+	templated_classes_std.buildClasses(elem_type);
 
 	// Device classes / types with knobs ... handled by these two lines
 	TemplatedClasses<tsc::TpsaVariantType> templated_classes_tpsa(m, "Tpsa");
-	templated_classes_tpsa.buildClasses(cell_void);
+	templated_classes_tpsa.buildClasses(elem_type);
 
 	// classes without knobs follow
 

--- a/python/src/interpolation.cc
+++ b/python/src/interpolation.cc
@@ -281,11 +281,17 @@ void py_thor_scsi_init_field_interpolation(py::module &m) {
 
 		py::class_<tsc::TwoDimensionalMultipolesTpsa, std::shared_ptr<tsc::TwoDimensionalMultipolesTpsa>>
 		    multipoles_tpsa(m, "TwoDimensionalMultipolesTpsa", multipoles_tpsa_base //, py::buffer_protocol()
-	    );
-	    add_methods_multipoles<tsc::TpsaVariantType, tsc::TwoDimensionalMultipolesTpsa>(multipoles_tpsa);
-	    multipoles_tpsa
+			);
+		add_methods_multipoles<tsc::TpsaVariantType, tsc::TwoDimensionalMultipolesTpsa>(multipoles_tpsa);
+		multipoles_tpsa
 		    .def(py::init<const std::complex<double>, const unsigned int>(), "initalise multipoles",
 			 py::arg("default_value"), py::arg("h_max") = tsc::max_multipole)
+		    /*
+		    // shall one return a list of base objects ?
+		    .def("get_multipole",  [](tsc::TwoDimensionalMultipolesTpsa& inst, const unsigned int n)
+			{ auto obj = inst.getMultipole(n); }
+			)
+		    */
 		    ;
 
 

--- a/python/src/radiation.cc
+++ b/python/src/radiation.cc
@@ -37,9 +37,10 @@ class PyRadDel: public tse::RadiationDelegate {
 };
 
 
-class PyRadDelKickInt: public tse::RadiationDelegateKickInterface {
-	using tse::RadiationDelegateKickInterface::RadiationDelegateKickInterface;
-	void view(const tse::FieldKickAPI& elem, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState os, const int cnt) override {
+template <class FC>
+class PyRadDelKickInt: public tse::RadiationDelegateKickInterfaceKnobbed<FC> {
+	using tse::RadiationDelegateKickInterfaceKnobbed<FC>::RadiationDelegateKickInterfaceKnobbed;
+	void view(const FC& elem, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState os, const int cnt) override {
 		PYBIND11_OVERRIDE_PURE(void, tse::RadiationDelegateKickInterface, view, elem, ps, os, cnt);
 	}
 	/*
@@ -47,26 +48,55 @@ class PyRadDelKickInt: public tse::RadiationDelegateKickInterface {
 		PYBIND11_OVERRIDE_PURE(void, tse::RadiationDelegateKickInterface, view, elem, ps, os, cnt);
 	}
 	*/
-	void view(const tse::FieldKickAPI& elem, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState os, const int cnt) override {
+	void view(const FC& elem, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState os, const int cnt) override {
 		PYBIND11_OVERRIDE_PURE(void, tse::RadiationDelegateKickInterface, view, elem, ps, os, cnt);
 	}
 };
 
-class PyRadDelKick: public tse::RadiationDelegateKick {
-	using tse::RadiationDelegateKick::RadiationDelegateKick;
-	void view(const tse::FieldKickAPI& elem, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState os, const int cnt) override {
-		PYBIND11_OVERRIDE(void, tse::RadiationDelegateKick, view, elem, ps, os, cnt);
+
+template <class FC>
+class PyRadDelKick: public tse::RadiationDelegateKickKnobbed<FC> {
+	using tse::RadiationDelegateKickKnobbed<FC>::RadiationDelegateKickKnobbed;
+	void view(const FC& elem, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState os, const int cnt) override {
+		PYBIND11_OVERRIDE(void, tse::RadiationDelegateKickKnobbed<FC>, view, elem, ps, os, cnt);
 	}
 	/*
 	void view(const tse::FieldKickAPI& elem, const gtpsa::ss_vect<tps> &ps, const enum tsc::ObservedState os, const int cnt) override {
 		PYBIND11_OVERRIDE(void, tse::RadiationDelegateKick, view, elem, ps, os, cnt);
 	}
 	*/
-	void view(const tse::FieldKickAPI& elem, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState os, const int cnt) override {
-		PYBIND11_OVERRIDE(void, tse::RadiationDelegateKick, view, elem, ps, os, cnt);
+	void view(const FC& elem, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState os, const int cnt) override {
+		PYBIND11_OVERRIDE(void, tse::RadiationDelegateKickKnobbed<FC>, view, elem, ps, os, cnt);
 	}
 };
 
+
+template<typename FC, typename Class>
+void add_methods_radiation_field_kick(py::class_<Class> t_kick)
+{
+
+
+    //typedef tse::RadiationDelegateKick<FC> rk_t;
+
+
+    t_kick
+		.def("reset",                                 &Class::reset)
+		.def("get_curly_dHx",                         &Class::getCurlydHx)
+		.def("get_delegator_name",                    &Class::getDelegatorName)
+		.def("get_delegator_index",                   &Class::getDelegatorIndex)
+		.def("get_synchrotron_integrals_increments",  &Class::getSynchrotronIntegralsIncrement)
+		.def("get_diffusion_coefficients_increments", &Class::getDiffusionCoefficientsIncrement)
+		.def("compute_diffusion",                     &Class::computeDiffusion)
+		.def("is_computing_diffusion",                &Class::isComputingDiffusion)
+		.def("set_energy",                            &Class::setEnergy)
+		.def("get_energy",                            &Class::getEnergy)
+		.def("view",
+		     py::overload_cast<const FC&, const gtpsa::ss_vect<double> &, const enum tsc::ObservedState, const int>(&Class::view))
+		.def("view",
+		     py::overload_cast<const FC&, const gtpsa::ss_vect<double> &, const enum tsc::ObservedState, const int>(&Class::view))
+		.def("__repr__",                           &Class::repr)
+	;
+}
 
 void py_thor_scsi_init_radiation(py::module &m)
 {
@@ -87,28 +117,32 @@ void py_thor_scsi_init_radiation(py::module &m)
 		     py::overload_cast<const tse::ElemType&, const gtpsa::ss_vect<double> &, const enum tsc::ObservedState, const int>(&tse::RadiationDelegate::view))
 		.def(py::init<>());
 
-	py::class_<tse::RadiationDelegateKickInterface, PyRadDelKickInt, std::shared_ptr<tse::RadiationDelegateKickInterface>> rad_del_kick_int(m, "RadiationDelegateKickInterface");
+	typedef tse::FieldKickAPIKnobbed<tsc::StandardDoubleType> fka_dt;
+	typedef tse::FieldKickAPIKnobbed<tsc::TpsaVariantType> fka_dvt;
+
+	typedef tse::RadiationDelegateKickInterfaceKnobbed<fka_dt>  rdlki_d_t;
+	typedef tse::RadiationDelegateKickInterfaceKnobbed<fka_dvt> rdlki_t_t;
+	py::class_<rdlki_d_t, PyRadDelKickInt<fka_dt>, std::shared_ptr<rdlki_d_t>> rad_del_kick_int(m, "RadiationDelegateKickInterface");
+	rad_del_int
+		//.def("__repr__", &tse::RadiationDelegateKickInterface::repr)
+		.def(py::init<>());
+	py::class_<rdlki_t_t, PyRadDelKickInt<fka_dvt>, std::shared_ptr<rdlki_t_t>> rad_del_kick_int_tpsa(m, "RadiationDelegateKickInterfaceTpsa");
 	rad_del_int
 		//.def("__repr__", &tse::RadiationDelegateKickInterface::repr)
 		.def(py::init<>());
 
 	// Why did it not end up at Johan?
-	py::class_<tse::RadiationDelegateKick, PyRadDelKick, std::shared_ptr<tse::RadiationDelegateKick>>(m, "RadiationDelegateKick", rad_del_kick_int)
-		.def("reset",                                 &tse::RadiationDelegateKick::reset)
-		.def("get_curly_dHx",                         &tse::RadiationDelegateKick::getCurlydHx)
-		.def("get_delegator_name",                    &tse::RadiationDelegateKick::getDelegatorName)
-		.def("get_delegator_index",                   &tse::RadiationDelegateKick::getDelegatorIndex)
-		.def("get_synchrotron_integrals_increments",  &tse::RadiationDelegateKick::getSynchrotronIntegralsIncrement)
-		.def("get_diffusion_coefficients_increments", &tse::RadiationDelegateKick::getDiffusionCoefficientsIncrement)
-		.def("compute_diffusion",                     &tse::RadiationDelegateKick::computeDiffusion)
-		.def("is_computing_diffusion",                &tse::RadiationDelegateKick::isComputingDiffusion)
-		.def("set_energy",                            &tse::RadiationDelegateKick::setEnergy)
-		.def("get_energy",                            &tse::RadiationDelegateKick::getEnergy)
-		.def("view",
-		     py::overload_cast<const tse::FieldKickAPI&, const gtpsa::ss_vect<double> &, const enum tsc::ObservedState, const int>(&tse::RadiationDelegateKick::view))
-		.def("view",
-		     py::overload_cast<const tse::FieldKickAPI&, const gtpsa::ss_vect<double> &, const enum tsc::ObservedState, const int>(&tse::RadiationDelegateKick::view))
-		.def("__repr__",                           &tse::RadiationDelegateKick::repr)
+	typedef tse::RadiationDelegateKickKnobbed<fka_dt>  rdlk_d_t;
+	typedef tse::RadiationDelegateKickKnobbed<fka_dvt> rdlk_t_t;
+
+	py::class_<rdlk_d_t, PyRadDelKick<fka_dt>, std::shared_ptr<rdlk_d_t>> rad_del_kick(m, "RadiationDelegateKick", rad_del_kick_int);
+	rad_del_kick
 		.def(py::init<>());
+	add_methods_radiation_field_kick<fka_dt, rdlk_d_t>(rad_del_kick);
+
+	py::class_<rdlk_t_t, PyRadDelKick<fka_dvt>, std::shared_ptr<rdlk_t_t>> rad_del_kick_tpsa(m, "RadiationDelegateKickTpsa", rad_del_kick_int);
+	rad_del_kick_tpsa
+		.def(py::init<>());
+	add_methods_radiation_field_kick<fka_dvt, rdlk_t_t>(rad_del_kick_tpsa);
 
 }

--- a/python/src/thor_scsi.h
+++ b/python/src/thor_scsi.h
@@ -8,22 +8,6 @@
 #include <gtpsa/tpsa.hpp>
 #include <tps/tps_type.h>
 
-#ifndef NO_TPSA
-  #error "NO_TPSA not defined"
-  // Abort compilation.
-  #include <stop here>
-#else
-/* worth a util header ...*/
-#define STRINGIFY(a_var) #a_var
-#define TOSTRING(a_str) STRINGIFY(a_str)
-#define DISPLAY_VAR(a_var) #a_var  " = " STRINGIFY(a_var)
-#define DISPLAY_AT() __FILE__ ":" TOSTRING(__LINE__)
-#define DISPLAY_VAR_AT(a_var)  DISPLAY_AT() " "  DISPLAY_VAR(NO_TPSA)
-
-#pragma message(DISPLAY_VAR_AT(NO_TPSA))
-
-//#pragma message("thor_py.cc: "NO_TPSA = " STRINGIFY(NO_TPSA) NO_TPSA)
-#endif
 
 namespace py = pybind11;
 

--- a/src/thor_scsi/CMakeLists.txt
+++ b/src/thor_scsi/CMakeLists.txt
@@ -2,9 +2,10 @@ include(../../cmake/gpp_warnings.cmake)
 
 add_subdirectory(core)
 
-# add_compile_definitions(
-#   GTSPA_ONLY_OPTIMISED_OPS
-#  )
+add_compile_definitions(
+  #   GTSPA_ONLY_OPTIMISED_OPS
+  SYNCHROTRON_INTEGRALS
+)
 
 if(FLAME_INTERNAL)
     set(flame_INCLUDE_DIR "${flame_SOURCE_DIR}/src/")

--- a/src/thor_scsi/core/elements_basis.h
+++ b/src/thor_scsi/core/elements_basis.h
@@ -25,10 +25,11 @@ namespace thor_scsi::core {
 		//< Element virtual base class.
 		using thor_scsi::core::ConfigType;
 
-        template<class C, typename = typename C::double_type>
+        //template<class C, typename = typename C::double_type>
         class ElemTypeKnobbed : public CellVoid {
         protected:
-		using double_type = typename C::double_type;
+		// using double_type = typename C::double_type;
+		using double_type = double;
 #warning "not yet supporting PL as tpsa"
 		double PL = 0.0;                        ///< Length[m].
 
@@ -161,8 +162,9 @@ namespace thor_scsi::core {
 
 		};
 
-        typedef class ElemTypeKnobbed<thor_scsi::core::StandardDoubleType> ElemType;
-        typedef class ElemTypeKnobbed<thor_scsi::core::TpsaVariantType> ElemTypeEng;
+	    typedef class ElemTypeKnobbed ElemType;
+        // typedef class ElemTypeKnobbed<thor_scsi::core::StandardDoubleType> ElemType;
+        // typedef class ElemTypeKnobbed<thor_scsi::core::TpsaVariantType> ElemTypeEng;
 
 
 }

--- a/src/thor_scsi/core/transform.h
+++ b/src/thor_scsi/core/transform.h
@@ -9,6 +9,7 @@
 /* required for parameter study */
 using gtpsa::sin;
 using gtpsa::cos;
+// using gtpsa::atan2;
 
 /*
  * Should I separate the coefficients from the implementation ...

--- a/src/thor_scsi/elements/drift.h
+++ b/src/thor_scsi/elements/drift.h
@@ -13,9 +13,9 @@ namespace thor_scsi::elements {
 		using thor_scsi::core::ElemTypeKnobbed;
 		using thor_scsi::core::ConfigType;
 		template<class C>
-		class DriftTypeWithKnob : public ElemTypeKnobbed<C> {
+		class DriftTypeWithKnob : public ElemTypeKnobbed /* <C> */ {
 		public:
-			using base = ElemTypeKnobbed<C>;
+			using base = ElemTypeKnobbed /* <C> */ ;
 			inline DriftTypeWithKnob(const Config &config) :
 				base(config)
 				{

--- a/src/thor_scsi/elements/element_local_coordinates.h
+++ b/src/thor_scsi/elements/element_local_coordinates.h
@@ -18,12 +18,12 @@ namespace thor_scsi::elements {
 	 *      transformation should contain a constant part and a random part
 	 */
 	 template<class C>
-	class LocalCoordinatesKnobbed : public ElemTypeKnobbed<C> {
+	 class LocalCoordinatesKnobbed : public ElemTypeKnobbed /* <C> */ {
 
 	public:
-		inline LocalCoordinatesKnobbed(const Config &config) : ElemTypeKnobbed<C>(config){}
+		 inline LocalCoordinatesKnobbed(const Config &config) : ElemTypeKnobbed /* <C> */ (config){}
 		virtual ~LocalCoordinatesKnobbed(){}
-		LocalCoordinatesKnobbed(LocalCoordinatesKnobbed&& o) : ElemTypeKnobbed<C>(std::move(o)) {
+		 LocalCoordinatesKnobbed(LocalCoordinatesKnobbed&& o) : ElemTypeKnobbed /* <C> */ (std::move(o)) {
 			/*
 			std::cerr << __FILE__ << "::" << __FUNCTION__ << " ctor @ " << __LINE__
 				  << " name " << this->name << std::endl;

--- a/src/thor_scsi/elements/field_kick.cc
+++ b/src/thor_scsi/elements/field_kick.cc
@@ -287,6 +287,8 @@ inline void tse::FieldKickForthOrder<C>::_localPropagate(tsc::ConfigType &conf, 
 #ifdef SYNCHROTRON_INTEGRALS
 	// computeRadiationIntegralsStart
 	parent->_synchrotronIntegralsInit(conf, ps);
+#else
+#error "Only compiling with synchrotron integrals"
 #endif /* SYNCHROTRON_INTEGRALS */
 
 	/* 4th order integration steps  */

--- a/src/thor_scsi/elements/field_kick.h
+++ b/src/thor_scsi/elements/field_kick.h
@@ -431,10 +431,17 @@ namespace thor_scsi::elements {
             return this->integ4O;
         }
 
+        /*
+         * radiation delegate part
+         */
+    public:
+        typedef thor_scsi::elements::RadiationDelegateKickKnobbed<thor_scsi::elements::FieldKickAPIKnobbed<C>> rad_del_t;
 
+    protected:
+        std::shared_ptr<rad_del_t> rad_del;
 
-
-		inline void setRadiationDelegate(std::shared_ptr<thor_scsi::elements::RadiationDelegateKick> p){
+    public:
+		inline void setRadiationDelegate(std::shared_ptr<rad_del_t> p){
 			this->rad_del = p;
 		}
 		inline auto getRadiationDelegate(void) const {
@@ -449,6 +456,7 @@ namespace thor_scsi::elements {
 			return this->rad_del.get();
 		}
 
+    public:
 		template<typename T>
 		inline void _synchrotronIntegralsInit(const thor_scsi::core::ConfigType &conf,  gtpsa::ss_vect<T> &ps){
 			if(this->computeSynchrotronIntegrals(conf)){
@@ -466,7 +474,6 @@ namespace thor_scsi::elements {
 			if(this->computeSynchrotronIntegrals(conf)){
 				auto obj = this->_getRadiationDelegate();
 				if(obj){
-
 					obj->view(*this, ps, thor_scsi::core::ObservedState::end, 0);
 				}
 			}
@@ -490,9 +497,6 @@ namespace thor_scsi::elements {
 		FieldKickForthOrder<C> integ4O;
 		int  Pmethod;                 ///< Integration Method.
 		bool Pthick;                  ///< Thick or thin element
-
-	protected:
-		std::shared_ptr<thor_scsi::elements::RadiationDelegateKick> rad_del;
 
 	};
 

--- a/src/thor_scsi/elements/radiation_delegate.cc
+++ b/src/thor_scsi/elements/radiation_delegate.cc
@@ -18,8 +18,8 @@ std::string tse::RadiationDelegateInterface::repr(void) const
   return strm.str();
 }
 
-template<>
-std::string tse::RadiationDelegateKickInterface::repr(void) const
+template<class FC>
+std::string tse::RadiationDelegateKickInterfaceKnobbed<FC>::repr(void) const
 {
   std::stringstream strm;
   this->show(strm, 0);
@@ -27,15 +27,18 @@ std::string tse::RadiationDelegateKickInterface::repr(void) const
   return strm.str();
 }
 
+
+template<class EC>
 template <typename T>
-inline void tse::RadiationDelegate::computeAndStoreCurlyH(const gtpsa::ss_vect<T> &ps)
+inline void tse::RadiationDelegateKnobbed<EC>::computeAndStoreCurlyH(const gtpsa::ss_vect<T> &ps)
 {
 	//throw std::runtime_error("computeAndStoreCurlyH needs implementation" );
 	this->curly_dH_x = get_curly_H(ps);
 }
 
+template<class EC>
 template <typename T>
-inline void tse::RadiationDelegate::_view(const tsc::ElemType& elem, const gtpsa::ss_vect<T> &ps, const enum tsc::ObservedState state, const int cnt)
+inline void tse::RadiationDelegateKnobbed<EC>::_view(const EC& elem, const gtpsa::ss_vect<T> &ps, const enum tsc::ObservedState state, const int cnt)
 {
   switch(state){
   case tsc::ObservedState::start:
@@ -57,7 +60,8 @@ inline void tse::RadiationDelegate::_view(const tsc::ElemType& elem, const gtpsa
 //void tse::RadiationDelegate::_view(const tsc::ElemType& elem, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState state, const int cnt);
 //template
 //void tse::RadiationDelegate::_view(const tsc::ElemType& elem, const gtpsa::ss_vect<tps> &ps, const enum tsc::ObservedState state, const int cnt);
-void tse::RadiationDelegate::view(const tsc::ElemType& elem, const gtpsa::ss_vect<double>      &ps, const enum tsc::ObservedState state, const int cnt)
+template<class EC>
+void tse::RadiationDelegateKnobbed<EC>::view(const EC& elem, const gtpsa::ss_vect<double>      &ps, const enum tsc::ObservedState state, const int cnt)
 {
 	_view(elem, ps, state, cnt);
 }
@@ -67,13 +71,15 @@ void tse::RadiationDelegate::view(const tsc::ElemType& elem, const gtpsa::ss_vec
 	_view(elem, ps, state, cnt);
 }
 */
-void tse::RadiationDelegate::view(const tsc::ElemType& elem, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState state, const int cnt)
+template<class EC>
+void tse::RadiationDelegateKnobbed<EC>::view(const EC& elem, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState state, const int cnt)
 {
 	_view(elem, ps, state, cnt);
 }
 
+template<class FC>
 template<typename T>
-inline void tse::RadiationDelegateKick::synchrotronIntegralsFinish(const FieldKickAPI &kick, const gtpsa::ss_vect<T> &ps)
+inline void tse::RadiationDelegateKickKnobbed<FC>::synchrotronIntegralsFinish(const FC &kick, const gtpsa::ss_vect<T> &ps)
 {
        throw std::runtime_error("synchrotron integral steps need to be implemented ");
 #if 0
@@ -96,8 +102,9 @@ inline void tse::RadiationDelegateKick::synchrotronIntegralsFinish(const FieldKi
 #endif
 }
 
+template<class FC>
 template<typename T>
-inline void tse::RadiationDelegateKick::synchrotronIntegralsStep(const gtpsa::ss_vect<T> &ps)
+inline void tse::RadiationDelegateKickKnobbed<FC>::synchrotronIntegralsStep(const gtpsa::ss_vect<T> &ps)
 {
 
 #if 0
@@ -127,8 +134,9 @@ pow(gtpsa::tpsa& arg, int power)
 	return gtpsa::pow(arg, power);
 }
 
+template<class FC>
 template<typename T>
-inline void tse::RadiationDelegateKick::diffusion(const T &B2_perp,  const T &ds, const T &p_s0,  const gtpsa::ss_vect<T> &A)
+inline void tse::RadiationDelegateKickKnobbed<FC>::diffusion(const T &B2_perp,  const T &ds, const T &p_s0,  const gtpsa::ss_vect<T> &A)
 {
 
 
@@ -156,9 +164,9 @@ inline void tse::RadiationDelegateKick::diffusion(const T &B2_perp,  const T &ds
 #endif
 }
 
-
+template<class FC>
 template <typename T>
-inline void tse::RadiationDelegateKick::_view(const FieldKickAPI& kick, const gtpsa::ss_vect<T> &ps, const enum tsc::ObservedState state, const int cnt)
+inline void tse::RadiationDelegateKickKnobbed<FC>::_view(const FC& kick, const gtpsa::ss_vect<T> &ps, const enum tsc::ObservedState state, const int cnt)
 {
   switch(state){
   case tsc::ObservedState::start:
@@ -179,13 +187,16 @@ inline void tse::RadiationDelegateKick::_view(const FieldKickAPI& kick, const gt
     return;
   }
 }
-void tse::RadiationDelegate::show(std::ostream& strm, int level) const{
+
+template<class EC>
+void tse::RadiationDelegateKnobbed<EC>::show(std::ostream& strm, int level) const{
   strm << "RadiationDelegate for "
        << this->delegator_name << "["<< this->delegator_index << "]"
        <<" curly_dH_x " << this->curly_dH_x;
 }
 
-void tse::RadiationDelegateKick::show(std::ostream& strm, int level) const
+template<class FC>
+void tse::RadiationDelegateKickKnobbed<FC>::show(std::ostream& strm, int level) const
 {
   strm << "RadiationDelegateKick for "
        << this->delegator_name << "["<< this->delegator_index << "]"
@@ -236,7 +247,8 @@ void get_B2(const double h_ref, const std::array<T,3> B, const gtpsa::ss_vect<T>
   //  B2_par = sqr(B[X_]*e[X_]+B[Y_]*e[Y_]+B[Z_]*e[Z_]);
 }
 
-void tse::RadiationDelegateKick::setEnergy(const double val)
+template<class EC>
+void tse::RadiationDelegateKickKnobbed<EC>::setEnergy(const double val)
 {
   // energy in eV
   this->energy = val;
@@ -258,9 +270,9 @@ static bool check_ps_finite(gtpsa::ss_vect<T>& ps, const double max_val = 1e3)
 	return check_ps_finite;
 }
 
-
+template<class FC>
 template<typename T>
-void tse::RadiationDelegateKick::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<T> &ps, const double L,
+void tse::RadiationDelegateKickKnobbed<FC>::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<T> &ps, const double L,
 				     const double h_ref, const std::array<T, 3> B)
 {
 
@@ -381,7 +393,8 @@ void tse::RadiationDelegateKick::radiate(const thor_scsi::core::ConfigType &conf
 
 //template void tse::RadiationDelegate::_view(const FieldKickAPI& kick, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState state, const int cnt);
 //template void tse::RadiationDelegate::_view(const FieldKickAPI& kick, const gtpsa::ss_vect<tps> &ps, const enum tsc::ObservedState state, const int cnt);
-void tse::RadiationDelegateKick::view(const FieldKickAPI& kick, const gtpsa::ss_vect<double> &ps, const enum ObservedState state, const int cnt)
+template<class FC>
+void tse::RadiationDelegateKickKnobbed<FC>::view(const FC& kick, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState state, const int cnt)
 {
 	std::cout<< "Rad Del.view(gtpsa::ss_vect<double>) for element " << kick.name << "at index" << kick.index << std::endl;
 	_view(kick, ps, state, cnt);
@@ -394,14 +407,51 @@ void tse::RadiationDelegateKick::view(const FieldKickAPI& kick, const gtpsa::ss_
 	_view(kick, ps, state, cnt);
 }
 */
-void tse::RadiationDelegateKick::view(const FieldKickAPI& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum ObservedState state, const int cnt)
+template<class FC>
+void tse::RadiationDelegateKickKnobbed<FC>::view(const FC& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState state, const int cnt)
 {
 	std::cout<< "Rad Del.view(gtpsa::ss_vect<gtpa::tpsa>) for element " << kick.name << "at index" << kick.index << std::endl;
 	_view(kick, ps, state, cnt);
 }
-template void tse::RadiationDelegateKick::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<double>      &ps, const double L,
-						  const double h_ref, const std::array<double, 3>      B);
+
+typedef tsc::ElemTypeKnobbed elem_t;
+template
+void tse::RadiationDelegateKnobbed<elem_t>::view(const elem_t& kick, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState state, const int cnt);
+template
+void tse::RadiationDelegateKnobbed<elem_t>::view(const elem_t& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState state, const int cnt);
+
+template void tse::RadiationDelegateKnobbed<elem_t>::show(std::ostream& strm, int level) const;
+typedef tse::FieldKickAPIKnobbed<tsc::StandardDoubleType> fka_dt;
+typedef tse::FieldKickAPIKnobbed<tsc::TpsaVariantType> fka_dvt;
+
+template
+void tse::RadiationDelegateKickKnobbed<fka_dt>::view(const fka_dt& kick, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState state, const int cnt);
+template
+void tse::RadiationDelegateKickKnobbed<fka_dvt>::view(const fka_dvt& kick, const gtpsa::ss_vect<double> &ps, const enum tsc::ObservedState state, const int cnt);
+
+template
+void tse::RadiationDelegateKickKnobbed<fka_dt>::view(const fka_dt& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState state, const int cnt);
+template
+void tse::RadiationDelegateKickKnobbed<fka_dvt>::view(const fka_dvt& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum tsc::ObservedState state, const int cnt);
+
+
+template void tse::RadiationDelegateKickKnobbed<fka_dt>::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<double>      &ps, const double L,
+                                                                 const double h_ref, const std::array<double, 3>      B);
+template void tse::RadiationDelegateKickKnobbed<fka_dvt>::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<double>      &ps, const double L,
+                                                                 const double h_ref, const std::array<double, 3>      B);
 // template void tse::RadiationDelegateKick::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<tps>         &ps, const double L,
 //						  const double h_ref, const std::array<tps, 3>         B);
-template void tse::RadiationDelegateKick::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<gtpsa::tpsa> &ps, const double L,
-						  const double h_ref, const std::array<gtpsa::tpsa, 3> B);
+
+template void tse::RadiationDelegateKickKnobbed<fka_dt>::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<gtpsa::tpsa> &ps, const double L,
+                                                                   const double h_ref, const std::array<gtpsa::tpsa, 3> B);
+template void tse::RadiationDelegateKickKnobbed<fka_dvt>::radiate(const thor_scsi::core::ConfigType &conf, gtpsa::ss_vect<gtpsa::tpsa> &ps, const double L,
+                                                                   const double h_ref, const std::array<gtpsa::tpsa, 3> B);
+
+template void tse::RadiationDelegateKickKnobbed<fka_dt>::show(std::ostream& strm, int level) const;
+template void tse::RadiationDelegateKickKnobbed<fka_dvt>::show(std::ostream& strm, int level) const;
+
+template void tse::RadiationDelegateKickKnobbed<fka_dt>::setEnergy(const double val);
+template void tse::RadiationDelegateKickKnobbed<fka_dvt>::setEnergy(const double val);
+
+template std::string tse::RadiationDelegateKickInterfaceKnobbed<fka_dt>::repr(void) const;
+template std::string tse::RadiationDelegateKickInterfaceKnobbed<fka_dvt>::repr(void) const;

--- a/src/thor_scsi/elements/radiation_delegate.h
+++ b/src/thor_scsi/elements/radiation_delegate.h
@@ -6,11 +6,13 @@
 #include <array>
 
 namespace thor_scsi::elements {
-    using thor_scsi::core::ElemType;
-	class RadiationDelegate: public  RadiationDelegateInterface{
+	using thor_scsi::core::ElemType;
+
+	template<class EC>
+	class RadiationDelegateKnobbed: public  RadiationDelegateInterfaceKnobbed<EC>{
 	public:
-		~RadiationDelegate(void){};
-		inline RadiationDelegate(void)
+		~RadiationDelegateKnobbed(void){};
+		inline RadiationDelegateKnobbed(void)
 			: curly_dH_x(0e0)
 			, delegator_name("")
 			, delegator_index(-1)
@@ -26,9 +28,9 @@ namespace thor_scsi::elements {
 		/*
 		 * Used for computing curly_dHx
 		 */
-		virtual void view(const ElemType& kick, const gtpsa::ss_vect<double>      &ps, const enum ObservedState state, const int cnt) override;
+		virtual void view(const EC& kick, const gtpsa::ss_vect<double>      &ps, const enum ObservedState state, const int cnt) override;
 		// virtual void view(const ElemType& kick, const gtpsa::ss_vect<tps>         &ps, const enum ObservedState state, const int cnt) override;
-		virtual void view(const ElemType& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum ObservedState state, const int cnt) override;
+		virtual void view(const EC& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum ObservedState state, const int cnt) override;
 
 		virtual void show(std::ostream& strm, int level) const override final;
 
@@ -40,7 +42,7 @@ namespace thor_scsi::elements {
 		}
 	private:
 		template<typename T>
-		inline void _view(const ElemType&, const gtpsa::ss_vect<T> &ps, const enum ObservedState state, const int cnt);
+		inline void _view(const EC&, const gtpsa::ss_vect<T> &ps, const enum ObservedState state, const int cnt);
 
 		template<typename T>
 		inline void computeAndStoreCurlyH(const gtpsa::ss_vect<T> &ps);
@@ -50,15 +52,20 @@ namespace thor_scsi::elements {
 		int delegator_index;
 	};
 
-    typedef RadiationDelegateKickInterfaceKnobbed<thor_scsi::core::StandardDoubleType> RadiationDelegateKickInterface;
+	typedef RadiationDelegateKickInterfaceKnobbed<ElemType> RadiationDelegateKickInterface;
 	/**
 	 *
 	 * @note synchrotron integrals are not used nor has their
 	 *       functionality been checked
 	 */
-	class RadiationDelegateKick: public RadiationDelegateKickInterface {
+
+	/*
+	 * EC typically is FieldKickAPIKnobbed<C>
+	 */
+	template<class FC>
+	class RadiationDelegateKickKnobbed: public RadiationDelegateKickInterfaceKnobbed<FC> {
 	public:
-		RadiationDelegateKick(void)
+		RadiationDelegateKickKnobbed(void)
 			: curly_dH_x(0e0)
 			, index(0e0)
 			, dI( {0e0, 0e0, 0e0, 0e0, 0e0, 0e0} )
@@ -66,7 +73,7 @@ namespace thor_scsi::elements {
 			{
 			this->reset();
 		}
-		~RadiationDelegateKick(void){};
+		~RadiationDelegateKickKnobbed(void){};
 
 		/*
 		 * @brief: reset parameters for radiation
@@ -105,9 +112,9 @@ namespace thor_scsi::elements {
 		/*
 		 * Used for computing synchrotron integrals
 		 */
-		virtual void view(const FieldKickAPI& kick, const gtpsa::ss_vect<double>      &ps, const enum ObservedState state, const int cnt) override;
+		virtual void view(const FC& kick, const gtpsa::ss_vect<double>      &ps, const enum ObservedState state, const int cnt) override;
 		// virtual void view(const FieldKickAPI& kick, const gtpsa::ss_vect<tps>         &ps, const enum ObservedState state, const int cnt) override;
-		virtual void view(const FieldKickAPI& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum ObservedState state, const int cnt) override;
+		virtual void view(const FC& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum ObservedState state, const int cnt) override;
 
 		virtual void show(std::ostream& strm, int level) const override final;
 		//virtual void view(const ElemType& kick, const gtpsa::ss_vect<double> &ps, const enum ObservedState state, const int cnt) override final;
@@ -159,7 +166,7 @@ namespace thor_scsi::elements {
 		 */
 		//
 		template<typename T>
-		inline void synchrotronIntegralsFinish(const FieldKickAPI &kick, const gtpsa::ss_vect<T> &ps);
+		inline void synchrotronIntegralsFinish(const FC &kick, const gtpsa::ss_vect<T> &ps);
 
 		// calculate the effect of radiation
 		template<typename T>
@@ -167,7 +174,7 @@ namespace thor_scsi::elements {
 		synchrotronIntegralsStep(const gtpsa::ss_vect<T> &ps);
 
 		template<typename T>
-		inline void _view(const FieldKickAPI&, const gtpsa::ss_vect<T> &ps, const enum ObservedState state, const int cnt);
+		inline void _view(const FC&, const gtpsa::ss_vect<T> &ps, const enum ObservedState state, const int cnt);
 
 		template<typename T>
 		void diffusion(const T &B2_perp, const T &ds, const T &p_s0,  const gtpsa::ss_vect<T> &A);
@@ -184,6 +191,9 @@ namespace thor_scsi::elements {
 		int delegator_index = -1;
 
 	};
+
+    typedef RadiationDelegateKnobbed<thor_scsi::core::ElemTypeKnobbed> RadiationDelegate;
+    typedef RadiationDelegateKickKnobbed<thor_scsi::elements::FieldKickAPIKnobbed<thor_scsi::core::StandardDoubleType>> RadiationDelegateKick;
 } // namespace thor_scsi::elements
 
 #endif /* _THOR_SCSI_RADIATION_DELEGATOR_H_ */

--- a/src/thor_scsi/elements/radiation_delegate_api.h
+++ b/src/thor_scsi/elements/radiation_delegate_api.h
@@ -8,13 +8,17 @@
 
 namespace thor_scsi::elements {
 	using thor_scsi::core::ObservedState;
-    template<class C>
+
+	/*
+	 * EC typically is thor_scsi::core::ElemTypeKnobbed<C>
+	 */
+	template<class EC>
 	class RadiationDelegateInterfaceKnobbed {
 	public:
 	        virtual ~RadiationDelegateInterfaceKnobbed(void){}
-		virtual void view(const thor_scsi::core::ElemTypeKnobbed<C>& elem, const gtpsa::ss_vect<double>      &ps, const enum ObservedState, const int cnt) = 0;
+		virtual void view(const EC& elem, const gtpsa::ss_vect<double>      &ps, const enum ObservedState, const int cnt) = 0;
 	    // virtual void view(const thor_scsi::core::ElemTypeKnobbed<C>& elem, const gtpsa::ss_vect<tps>         &ps, const enum ObservedState, const int cnt) = 0;
-		virtual void view(const thor_scsi::core::ElemTypeKnobbed<C>& elem, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum ObservedState, const int cnt) = 0;
+		virtual void view(const EC& elem, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum ObservedState, const int cnt) = 0;
 		virtual void show(std::ostream& strm, int level) const{
 			strm << "RadiationDelegateInterface";
 		}
@@ -22,14 +26,17 @@ namespace thor_scsi::elements {
 		std::string repr(void) const;
 
 	};
-    typedef RadiationDelegateInterfaceKnobbed<thor_scsi::core::StandardDoubleType> RadiationDelegateInterface;
+	typedef RadiationDelegateInterfaceKnobbed<thor_scsi::core::ElemType> RadiationDelegateInterface;
 
-    template<class C>
+	/*
+	 * EC typically is FieldKickAPIKnobbed<C>
+	 */
+	template<class FC>
 	class RadiationDelegateKickInterfaceKnobbed {
 	public:
 	        virtual ~RadiationDelegateKickInterfaceKnobbed(void){}
-		virtual void view(const FieldKickAPIKnobbed<C>& kick, const gtpsa::ss_vect<double>      &ps, const enum ObservedState, const int cnt) = 0;
-		virtual void view(const FieldKickAPIKnobbed<C>& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum ObservedState, const int cnt) = 0;
+		virtual void view(const FC& kick, const gtpsa::ss_vect<double>      &ps, const enum thor_scsi::core::ObservedState, const int cnt) = 0;
+		virtual void view(const FC& kick, const gtpsa::ss_vect<gtpsa::tpsa> &ps, const enum thor_scsi::core::ObservedState, const int cnt) = 0;
 	    // virtual void view(const FieldKickAPIKnobbed<C>& kick, const gtpsa::ss_vect<tps>         &ps, const enum ObservedState, const int cnt) = 0;
 		virtual void show(std::ostream& strm, int level) const{
 			strm << "RadiationDelegateKickInterface";
@@ -48,19 +55,20 @@ namespace thor_scsi::elements {
 	 * @f]
 	 *
 	 * @todo: depends on energy of ring .... currently taken from config ...
+	 *        put comment on correct place
 	 *
 	 * M. Sands "The hysics of Electron Storage Rings" SLAC-121, p. 98.
 	 */
 	//inline
-    template<typename C>
-	std::ostream& operator<<(std::ostream& strm, const RadiationDelegateKickInterfaceKnobbed<C>& rd)
+	template<typename FC>
+	std::ostream& operator<<(std::ostream& strm, const RadiationDelegateKickInterfaceKnobbed<FC>& rd)
 	{
 		rd.show(strm, 0);
 		return strm;
 	}
 
-    template<class C>
-	std::ostream& operator<<(std::ostream& strm, const RadiationDelegateInterfaceKnobbed<C>& rd)
+	template<class EC>
+	std::ostream& operator<<(std::ostream& strm, const RadiationDelegateInterfaceKnobbed<EC>& rd)
 	{
 		rd.show(strm, 0);
 		return strm;

--- a/src/thor_scsi/examples/build_accelerator.cc
+++ b/src/thor_scsi/examples/build_accelerator.cc
@@ -16,7 +16,7 @@ static int reg_done = ts::register_elements();
 
 int main(int argc, char * argv[])
 {
-    #if 0
+#if 0
     Config config_drift;
     Config config_bend;
     Config config;
@@ -49,7 +49,7 @@ int main(int argc, char * argv[])
     elems.reserve(2);
     std::cout <<  "Building elems"  << std::endl;
 
-#if 0
+#if 1
     {
 	/*
 	  const std::string bending_txt(

--- a/src/thor_scsi/std_machine/accelerator.h
+++ b/src/thor_scsi/std_machine/accelerator.h
@@ -23,7 +23,8 @@ namespace thor_scsi {
 		bool success;
 	};
 
-	class Accelerator : public thor_scsi::core::Machine {
+	template<class C>
+	class AcceleratorKnobbable : public thor_scsi::core::Machine {
 	public:
 
 		/**
@@ -35,7 +36,7 @@ namespace thor_scsi {
 		 * @warning consider if the marker is not better added manually to the lattice
 		 *          file
 		 */
-		Accelerator(const Config &conf, bool add_marker_at_start=false);
+		AcceleratorKnobbable(const Config &conf, bool add_marker_at_start=false);
 
 		/**
 		 * @brief inititsialse accelerator with a list of elements
@@ -47,9 +48,13 @@ namespace thor_scsi {
 		 *          file
 		 * @param conf
 		 */
-	        Accelerator(const std::vector<std::shared_ptr<thor_scsi::core::ElemType>>& elements,
-			    bool add_marker_at_start=false);
+		/*
+		*/
+		AcceleratorKnobbable(std::vector<std::shared_ptr<thor_scsi::core::CellVoid>>& elements,
+				     bool add_marker_at_start=false);
 
+		AcceleratorKnobbable(const std::vector<std::shared_ptr<thor_scsi::core::ElemTypeKnobbed>>& elements,
+				     bool add_marker_at_start=false);
 		/** @brief pass the given state through the machine
 		 *
 		 * @param conf Configuration of calculation
@@ -96,6 +101,9 @@ namespace thor_scsi {
 		template <typename T>
 		int _propagate(thor_scsi::core::ConfigType& conf, ss_vect<T>& ps, size_t start, int max, size_t n_turns, bool tracy_compatible_indexing);
 	};
+
+    typedef class AcceleratorKnobbable<thor_scsi::core::StandardDoubleType> Accelerator;
+    typedef class AcceleratorKnobbable<thor_scsi::core::TpsaVariantType> AcceleratorTpsa;
   }
 #endif // _THOR_SCSI_STD_MACHINE_ACCELERATOR_
 /*


### PR DESCRIPTION
providing synchrotron integrals:
   added define so that radiation integrals are called

   radiation delegate: make FieldKick(API) a class parameter
                       required to make view virtual(ble)
                       review if virtual functions are still required

core:
   element_basis: length not as a parameter yet supported, thus
                  not templated (would spill too much into python interface)

                  follow up:
                       elements: drift, local coordinates

   transform:     not importing atan2 (is it available in gtpsa)

std_machine:
    accelerator supporting elements with tpsa parameters
    simplified as ElemTypeKnobbable is currently not knobbable (length)

examples:
   build_accelerator: supporting lists again

python:
   thor_scsi.h:   removing tps related header
   elements:      providing knobbable elements
   interpolation: multipoles knobbable
   accelerator:   accelerator accepting knobbable devices

gtpsa:
   catchup to main